### PR TITLE
Fix range of target values

### DIFF
--- a/queries/training_features.sql
+++ b/queries/training_features.sql
@@ -51,4 +51,6 @@ SELECT
     END AS splitting
 FROM Training
 JOIN GroupSize
-  ON Training.company_response_to_consumer = GroupSize.company_response_to_consumer;
+  ON Training.company_response_to_consumer = GroupSize.company_response_to_consumer
+WHERE Training.company_response_to_consumer IN ('Untimely response', 'Closed', 'Closed with monetary relief',
+                                                'Closed with non-monetary relief', 'Closed with explanation');

--- a/queries/training_features.sql
+++ b/queries/training_features.sql
@@ -52,5 +52,10 @@ SELECT
 FROM Training
 JOIN GroupSize
   ON Training.company_response_to_consumer = GroupSize.company_response_to_consumer
-WHERE Training.company_response_to_consumer IN ('Untimely response', 'Closed', 'Closed with monetary relief',
-                                                'Closed with non-monetary relief', 'Closed with explanation');
+WHERE Training.company_response_to_consumer IN (
+  'Untimely response',
+  'Closed',
+  'Closed with monetary relief',
+  'Closed with non-monetary relief',
+  'Closed with explanation'
+);


### PR DESCRIPTION
As the Consumer Complaint Database is dynamically updated over time, there is a need to explicitly specify the values for the target column so that training would have enough examples for each class. 